### PR TITLE
Update CanvasRenderingContext2D.json

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -96,7 +96,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }


### PR DESCRIPTION
This property `.canvas` (back reference to the canvas creating the context) should be pretty standard and cross-browser compatible :)

- It's supported in all major browsers
- https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-canvas